### PR TITLE
FIX: stop logging models to mlflow

### DIFF
--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -290,8 +290,6 @@ class Loggers():
                 self.clearml.task.update_output_model(model_path=str(last),
                                                       model_name='Latest Model',
                                                       auto_delete_file=False)
-            if self.mlflow:
-                self.mlflow.log_model(model_path=last, model_name=f"{self.mlflow.model_name}/last/{epoch}")
 
         if self.comet_logger:
             self.comet_logger.on_model_save(last, epoch, final_epoch, best_fitness, fi)
@@ -323,10 +321,6 @@ class Loggers():
             # log stuff
             [self.mlflow.log_artifacts(f, "results") for f in files if f.exists()]
             self.mlflow.log_artifacts(self.save_dir / "results.csv", "results")
-            if last.exists():
-                self.mlflow.log_model(model_path=last, model_name=f"{self.mlflow.model_name}/last/{epoch}")
-            if best.exists():
-                self.mlflow.log_model(model_path=best, model_name=f"{self.mlflow.model_name}/best/{epoch}")
             self.mlflow.finish_run()
 
         if self.clearml and not self.opt.evolve:
@@ -427,9 +421,6 @@ class GenericLogger:
             art = wandb.Artifact(name=f"run_{wandb.run.id}_model", type="model", metadata=metadata)
             art.add_file(str(model_path))
             wandb.log_artifact(art)
-
-        if self.mlflow:
-            self.mlflow.log_model(model_path=model_path, model_name=f"{self.mlflow.model_name}/{epoch}")
 
     def update_params(self, params):
         # Update the paramters logged

--- a/utils/loggers/mlflow/mlflow_utils.py
+++ b/utils/loggers/mlflow/mlflow_utils.py
@@ -83,18 +83,6 @@ class MlflowLogger:
         else:
             self.mlflow.log_artifact(str(artifact.resolve()), artifact_path=relpath)
 
-    def log_model(self, model_path: Path, model_name: str = None) -> None:
-        """Member function to log model as an Mlflow model.
-
-        Args:
-            model_path: Path to the model .pt being logged
-            model_name: Name (or path) relative to experiment for logging model in mlflow
-        """
-        self.mlflow.pyfunc.log_model(artifact_path=self.model_name if model_name is None else model_name,
-                                     code_path=[str(ROOT.resolve())],
-                                     artifacts={"model_path": str(model_path.resolve())},
-                                     python_model=self.mlflow.pyfunc.PythonModel())
-
     def log_params(self, params: Dict[str, Any]) -> None:
         """Member funtion to log parameters.
         Mlflow doesn't have mutable parameters and so this function is used


### PR DESCRIPTION
They take too much space. Both the models and the whole yolov5 code is copied under `mlruns`